### PR TITLE
Change endpoint triggered by the bot to notify_refill

### DIFF
--- a/src/bot/checkApplications.ts
+++ b/src/bot/checkApplications.ts
@@ -2,7 +2,7 @@ import { getApiClients } from "../services/filplusService";
 import {
   getAllocators,
   getApplications,
-  postApplicationRefill,
+  postNotifyRefill,
   postApplicationTotalDCReached,
 } from "../services/backendService";
 import Metrics from "../services/awsService";
@@ -251,12 +251,10 @@ export const requestAllowance = async (
     }
   } else {
     try {
-      response = await postApplicationRefill(
-        application.ID,
+      response = await postNotifyRefill(
+        application["Issue Number"],
         owner,
         repo,
-        amountToRequest.amount.toString(),
-        amountToRequest.amountType,
       );
       logGeneral(
         `${config.logPrefix} ${owner}/${repo} - ${application.ID} Refill request sent for ${amountToRequest.amount} ${amountToRequest.amountType}`,

--- a/src/services/backendService.ts
+++ b/src/services/backendService.ts
@@ -121,23 +121,19 @@ export const getApplication = async (
  * @param {string} amount - The amount to refill.
  * @returns {Promise<RequestAllowanceReturn>} The response from the backend.
  */
-export const postApplicationRefill = async (
-  applicationId: string,
+export const postNotifyRefill = async (
+  issueNumber: string,
   owner: string,
   repo: string,
-  amount: string,
-  amountType,
 ): Promise<RequestAllowanceReturn> => {
   try {
     const response = await axios({
       method: "POST",
-      url: `${config.backendApi}/application/refill`,
+      url: `${config.backendApi}/application/notify_refill`,
       data: {
-        id: applicationId,
+        issue_number: issueNumber,
         owner,
         repo,
-        amount,
-        amount_type: amountType,
       },
     });
     return {
@@ -145,7 +141,7 @@ export const postApplicationRefill = async (
       success: response.data as boolean,
     };
   } catch (error) {
-    const errMessage = `Error accessing Backend API /application/refill ${owner}/${repo}: ${error.message}`;
+    const errMessage = `Error accessing Backend API /application/notify_refill ${owner}/${repo}: ${error.message}`;
     return {
       error: errMessage,
       success: false,

--- a/src/tests/checkApplications.test.ts
+++ b/src/tests/checkApplications.test.ts
@@ -16,10 +16,10 @@ describe("Datacap Allocation Functions", () => {
    */
   describe("checkApplications", () => {
     /**
-     * Before each test, mock `postApplicationRefill` in order to return a success response.
+     * Before each test, mock `postNotifyRefill` in order to return a success response.
      */
     beforeEach(() => {
-      jest.spyOn(backendService, "postApplicationRefill").mockResolvedValue({
+      jest.spyOn(backendService, "postNotifyRefill").mockResolvedValue({
         error: "",
         success: true,
       });
@@ -91,10 +91,10 @@ describe("Datacap Allocation Functions", () => {
     let apiClients;
 
     /**
-     * Before each test, mock `postApplicationRefill` in order to return a success response.
+     * Before each test, mock `postNotifyRefill` in order to return a success response.
      */
     beforeEach(() => {
-      jest.spyOn(backendService, "postApplicationRefill").mockResolvedValue({
+      jest.spyOn(backendService, "postNotifyRefill").mockResolvedValue({
         error: "Test error from getApiClients",
         success: true,
       });
@@ -682,8 +682,8 @@ describe("Datacap Allocation Functions", () => {
         error: "",
         success: true,
       });
-      const mockPostApplicationRefill = jest
-        .spyOn(backendService, "postApplicationRefill")
+      const mockpostNotifyRefill = jest
+        .spyOn(backendService, "postNotifyRefill")
         .mockImplementation(
           async () =>
             await Promise.resolve({
@@ -697,27 +697,23 @@ describe("Datacap Allocation Functions", () => {
         "keyko-io",
         "test-philip-the-second",
       );
-      expect(mockPostApplicationRefill).toHaveBeenCalledWith(
-        "222",
+      expect(mockpostNotifyRefill).toHaveBeenCalledWith(
+        "359",
         "keyko-io",
         "test-philip-the-second",
-        "512",
-        "TiB",
       );
     }, 60000);
   });
 
   /**
-   * Tests for postApplicationRefill functionality.
+   * Tests for postNotifyRefill functionality.
    */
-  describe("postApplicationRefill", () => {
-    it("should return correct data when calling postApplicationRefill", async () => {
-      const ret = await backendService.postApplicationRefill(
-        "222",
+  describe("postNotifyRefill", () => {
+    it("should return correct data when calling postNotifyRefill", async () => {
+      const ret = await backendService.postNotifyRefill(
+        "359",
         "keyko-io",
         "test-philip-the-second",
-        "500",
-        "TiB",
       );
       expect(ret.success).toEqual(true);
     }, 60000);


### PR DESCRIPTION
## Change endpoint triggered by the SSA Bot to notify_refill

**Description:**
Change the endpoint triggered by the bot from `application/refill` to `application/notify_refill`. The new endpoint will notify the allocator that the client has used 75% of their DataCap instead of starting the refill process.

##  Deployment Considerations:
No special actions are required.